### PR TITLE
Fix structure URL handling

### DIFF
--- a/system/expressionengine/third_party/resource_router/libraries/ResourceRouter/Router.php
+++ b/system/expressionengine/third_party/resource_router/libraries/ResourceRouter/Router.php
@@ -111,7 +111,7 @@ class Router {
 				// check for a :page:XX wildcard
 				if (preg_match('/\(?:page:(\d+)\)?/', $rule, $match) && isset($this->pageUris[$match[1]]))
 				{
-					$rule = str_replace($match[0], '('.ltrim($this->pageUris[$match[1]], '/').')', $rule);
+					$rule = str_replace($match[0], '('.trim($this->pageUris[$match[1]], '/').')', $rule);
 
 					// don't count a page uri as wildcard
 					$wildcard = strpos($rule, ':');


### PR DESCRIPTION
Allow ':page:3' to work using Structure in certain situations. Previously,
the regex generated for something like

```
:page:3/:any/:pagination
```

would look like

```
#^(news/)/([^/]+)((?:/P\d+)?)$#
```

and would never match because there are two slashes in a row. For whatever
reason, $this->pageUris has trailing slashes on all of the items, so those
trailing slashes need to be removed when creating the rule.
