### PR TITLE
Fix an issue where ExpressionEngine 3 would not serve a hidden template

### DIFF
--- a/system/expressionengine/third_party/resource_router/libraries/ResourceRouter/Router.php
+++ b/system/expressionengine/third_party/resource_router/libraries/ResourceRouter/Router.php
@@ -727,11 +727,15 @@ class Router {
 
 	/**
 	 * Get the set template
-	 * 
+	 *
 	 * @return mixed
 	 */
 	public function template()
 	{
+		// Set hidden template to empty string to make sure template can be
+		// served
+		ee()->config->set_item('hidden_template_indicator', '');
+
 		return array($this->templateGroup, $this->templateName);
 	}
 


### PR DESCRIPTION
I’m not sure why this is only an issue in EE 3 and not 2 since I ran into something similar with one of my own add-ons in EE 2 but in any event, I could not get EE 3 to serve a hidden template set by Resource Router without setting the hidden template indicator to an empty string. There may be a better way to do it but I don’t know what it is.