### PR TITLE
Add property to store XSS-cleaned wildcard value and magic method to retrieve it.

### DIFF
--- a/system/expressionengine/third_party/resource_router/libraries/ResourceRouter/Wildcard.php
+++ b/system/expressionengine/third_party/resource_router/libraries/ResourceRouter/Wildcard.php
@@ -16,6 +16,11 @@ class Wildcard {
 	protected $index;
 
 	/**
+	 * The XSS-cleaned value found in the URL for this matching wildcard.
+	 */
+	protected $clean_value;
+
+	/**
 	 * The value found in the URL for this matching wildcard.
 	 */
 	public $value;
@@ -37,6 +42,24 @@ class Wildcard {
 		$this->index = $index;
 		$this->value = $value;
 		$this->type = $type;
+	}
+
+	/**
+	 * Return the XSS-cleaned value if it exists, otherwise create
+	 * and return it.
+	 * @param  string $name Property name
+	 * @return string       XSS-cleaned property value
+	 */
+	public function __get($name)
+	{
+		if ($name == 'clean_value') {
+			if (isset($this->clean_value)) {
+				return $this->clean_value;
+			} else {
+				$this->clean_value = ee()->security->xss_clean($this->value);
+				return $this->clean_value;
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
I'm sure that like me, lots of folks are using these values in custom DB queries. Since user-input values should never be used in queries without sanitizing them, it makes sense to provide an XSS-cleaned version of the wildcard value.

And since `xss_clean()` has some overhead, we're holding off on doing it until the first time the property is requested.
