### PR TITLE
Adding WHERE conditions to properly restrict to current site

### DIFF
--- a/system/expressionengine/third_party/resource_router/libraries/ResourceRouter/Wildcard.php
+++ b/system/expressionengine/third_party/resource_router/libraries/ResourceRouter/Wildcard.php
@@ -149,6 +149,8 @@ class Wildcard {
 				ee()->db->where($key, (string) $value);
 			}
 		}
+		
+		ee()->db->where('categories.site_id', ee()->config->item('site_id'));
 
 		$select = array(
 			'cat_id',
@@ -240,6 +242,8 @@ class Wildcard {
 				ee()->db->where($key, (string) $value);
 			}
 		}
+		
+		ee()->db->where('channel_titles.site_id', ee()->config->item('site_id'));
 
 		$select = array(
 			'entry_id',


### PR DESCRIPTION
Wildcards of type `route_1_entry_id` and `route_1_category_id` need to be restricted to the current site; otherwise, if there are collisions in entry titles or category slugs, behavior is unpredictable.